### PR TITLE
@typescript-eslint/prefer-optional-chain を無効にする

### DIFF
--- a/ts-requiring-type-checking.js
+++ b/ts-requiring-type-checking.js
@@ -18,5 +18,6 @@ module.exports = {
         fixMixedExportsWithInlineTypeSpecifier: false,
       },
     ],
+    "@typescript-eslint/prefer-optional-chain": "off",
   },
 };


### PR DESCRIPTION
[prefer-optional-chain | typescript-eslint](https://typescript-eslint.io/rules/prefer-optional-chain/)

```ts
if (A || B) {
  // ...
}
```

のような条件式もエラーにしてくるので過剰なエラー
単純に ?? に置換できるものでもない